### PR TITLE
Fix compilation errors / severe warnings (Linux, g++ 12.2.0 / clang++ 14.0.6, Boost 1.80.0).

### DIFF
--- a/BackwardReasoning/BackwardReasoning.cpp
+++ b/BackwardReasoning/BackwardReasoning.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include "..\bbchallenge.h"
+#include "../bbchallenge.h"
 
 // This Decider can't offer much in the way of verification data. It just saves
 // Leftmost, Rightmost, MaxDepth, and nNodes. No verifier program has been written:

--- a/Bouncers/Bouncer.h
+++ b/Bouncers/Bouncer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <limits.h>
 #include <vector>
 #include "../bbchallenge.h"
 

--- a/Bouncers/DecideBouncers.cpp
+++ b/Bouncers/DecideBouncers.cpp
@@ -179,7 +179,7 @@ int main (int argc, char** argv)
         Reader.Read (MachineIndexList[i][j], MachineSpecList[i] + j * MACHINE_SPEC_SIZE) ;
         }
 
-      ThreadList[i] = new boost::thread (BouncerDecider::ThreadFunction, DeciderArray[i],
+      ThreadList[i] = new boost::thread (&BouncerDecider::ThreadFunction, DeciderArray[i],
         ChunkSize[i], MachineIndexList[i], MachineSpecList[i],
           VerificationEntryList[i], VERIF_AVERAGE_LENGTH * CHUNK_SIZE) ;
       }

--- a/Cyclers/Cyclers.cpp
+++ b/Cyclers/Cyclers.cpp
@@ -144,7 +144,7 @@ int main (int argc, char** argv)
     for (uint32_t i = 0 ; i < CommandLineParams::nThreads ; i++)
       {
       Reader.Read (MachineIndex, MachineSpecList[i], ChunkSize[i]) ;
-      ThreadList[i] = new boost::thread (Cycler::ThreadFunction,
+      ThreadList[i] = new boost::thread (&Cycler::ThreadFunction,
         CyclerArray[i], MachineIndex, ChunkSize[i], MachineSpecList[i], VerificationEntryList[i]) ;
       MachineIndex += ChunkSize[i] ;
       }

--- a/HaltingSegments/HaltingSegments.cpp
+++ b/HaltingSegments/HaltingSegments.cpp
@@ -29,7 +29,7 @@
 #include <set>
 #include <boost/thread.hpp>
 
-#include "..\bbchallenge.h"
+#include "../bbchallenge.h"
 
 #define CHUNK_SIZE 256 // Number of machines to assign to each thread
 
@@ -203,7 +203,7 @@ public:
         FreeChain = FreeChain -> Next[0] ;
         return Tree ;
         }
-      printf ("Pool exhaustion (%d exceeded)\n", EndOfPool - Pool), exit (1) ;
+      printf ("Pool exhaustion (%d exceeded)\n", int(EndOfPool - Pool)), exit (1) ;
       }
 
     void Free (TreeType* Tree)
@@ -360,7 +360,7 @@ int main (int argc, char** argv)
         Reader.Read (MachineIndexList[i][j], MachineSpecList[i] + j * MACHINE_SPEC_SIZE) ;
         }
 
-      ThreadList[i] = new boost::thread (HaltingSegment::ThreadFunction,
+      ThreadList[i] = new boost::thread (&HaltingSegment::ThreadFunction,
         DeciderArray[i], ChunkSize[i], MachineIndexList[i], MachineSpecList[i], VerificationEntryList[i]) ;
       }
 


### PR DESCRIPTION
Hi, I needed these changes to get a clean build.
(Clang also notices that a few deciders make "const uint8_t* MachineSpec" a write-only variable. I didn't "fix" that, because an unused-but-set variable is not necessarily a mistake.)
I didn't touch TranslatedCyclers/, since that's easier after its header file is committed.
Best,
Justin