### PR TITLE
Guarantee more portably that C stdio is going to do what we want.

### DIFF
--- a/BackwardReasoning/BackwardReasoning.cpp
+++ b/BackwardReasoning/BackwardReasoning.cpp
@@ -187,6 +187,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, Entry + 1, nDecided) ;
+      fflush (stdout) ;
       }
     }
   printf ("\n") ;

--- a/Bouncers/BouncerDecider.cpp
+++ b/Bouncers/BouncerDecider.cpp
@@ -60,7 +60,7 @@ bool BouncerDecider::RunDecider (const uint8_t* MachineSpec, uint8_t* Verificati
       case StepResult::OK: break ;
       case StepResult::OUT_OF_BOUNDS: return false ;
       case StepResult::HALT:
-        printf ("Unexpected HALT state reached! %lld\n", StepCount) ;
+        printf ("Unexpected HALT state reached! %llu\n", (unsigned long long) StepCount) ;
         printf ("SeedIndex = %d, TapeHead = %d\n", Load32 (MachineSpec - 4), TapeHead) ;
         exit (1) ;
       }

--- a/Bouncers/DecideBouncers.cpp
+++ b/Bouncers/DecideBouncers.cpp
@@ -245,6 +245,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, nCompleted, nDecided) ;
+      fflush (stdout) ;
       }
     }
   printf ("\n") ;

--- a/Bouncers/VerifyBouncers.cpp
+++ b/Bouncers/VerifyBouncers.cpp
@@ -92,6 +92,7 @@ int main (int argc, char** argv)
     if (Percent != LastPercent)
       {
       printf ("\r%d%%", Percent) ;
+      fflush (stdout) ;
       LastPercent = Percent ;
       }
 

--- a/Cyclers/Cyclers.cpp
+++ b/Cyclers/Cyclers.cpp
@@ -178,6 +178,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, nCompleted, nDecided) ;
+      fflush (stdout) ;
       }
     }
 
@@ -193,6 +194,7 @@ int main (int argc, char** argv)
   // The space-limited machines are not expected to yield any Cyclers,
   // so we just copy these to the umf
   printf ("Copying space-limited machines...") ;
+  fflush (stdout) ;
   for (uint32_t i = Reader.nTimeLimited ; i < Reader.nMachines ; i++)
     Write32 (fpUndecided, i) ;
   printf ("Done\n") ;

--- a/Cyclers/VerifyCyclers.cpp
+++ b/Cyclers/VerifyCyclers.cpp
@@ -74,6 +74,7 @@ int main (int argc, char** argv)
     if (Percent != LastPercent)
       {
       printf ("\r%d%%", Percent) ;
+      fflush (stdout) ;
       LastPercent = Percent ;
       }
 

--- a/FAR/DecideFAR.cpp
+++ b/FAR/DecideFAR.cpp
@@ -207,6 +207,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, nCompleted, nDecided) ;
+      fflush (stdout) ;
       }
     }
   printf ("\n") ;

--- a/FAR/VerifyFAR.cpp
+++ b/FAR/VerifyFAR.cpp
@@ -73,6 +73,7 @@ int main (int argc, char** argv)
     if (Percent != LastPercent)
       {
       printf ("\r%d%%", Percent) ;
+      fflush (stdout) ;
       LastPercent = Percent ;
       }
 

--- a/HaltingSegments/HaltingSegments.cpp
+++ b/HaltingSegments/HaltingSegments.cpp
@@ -399,6 +399,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, nCompleted, nDecided) ;
+      fflush (stdout) ;
       }
     }
   printf ("\n") ;

--- a/TranslatedCyclers/TranslatedCycler.cpp
+++ b/TranslatedCyclers/TranslatedCycler.cpp
@@ -61,7 +61,7 @@ bool TranslatedCycler::Run (const uint8_t* MachineSpec, uint8_t* VerificationEnt
       case StepResult::OK: break ;
       case StepResult::OUT_OF_BOUNDS: return false ;
       case StepResult::HALT:
-        printf ("Unexpected HALT state reached! %lld\n", StepCount) ;
+        printf ("Unexpected HALT state reached! %llu\n", (unsigned long long) StepCount) ;
         printf ("SeedIndex = %d, TapeHead = %d\n", Load32 (MachineSpec - 4), TapeHead) ;
         exit (1) ;
       }

--- a/TranslatedCyclers/TranslatedCyclers.cpp
+++ b/TranslatedCyclers/TranslatedCyclers.cpp
@@ -238,6 +238,7 @@ int main (int argc, char** argv)
       {
       LastPercent = Percent ;
       printf ("\r%d%% %d %d", Percent, nCompleted, nDecided) ;
+      fflush (stdout) ;
       }
     }
   printf ("\n") ;

--- a/TranslatedCyclers/VerifyTranslatedCyclers.cpp
+++ b/TranslatedCyclers/VerifyTranslatedCyclers.cpp
@@ -86,6 +86,7 @@ int main (int argc, char** argv)
     if (Percent != LastPercent)
       {
       printf ("\r%d%%", Percent) ;
+      fflush (stdout) ;
       LastPercent = Percent ;
       }
 


### PR DESCRIPTION
In practice, this should fix progress indicators not showing up and reduce warnings for clang++ users.
More detail: whether the progress indicators work at all depends on implementation-defined I/O buffering behavior. Flush-after-newline is common, and badly behaved here. I'd see nothing until the decider tried to report progress several dozen times. Looks like Microsoft's libc is different.
Cheers,
Justin