### PR TITLE
Quick-fix the compile.

### DIFF
--- a/Bouncers/Bouncer.h
+++ b/Bouncers/Bouncer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <limits.h>
 #include <vector>
 #include "../TuringMachine.h"
 

--- a/Params.h
+++ b/Params.h
@@ -83,3 +83,7 @@ public:
 
   FILE* fpUndecided ;
   } ;
+
+class VerifierParams : public CommonParams
+  {
+  } ;


### PR DESCRIPTION
Note: I am sure we want <limits.h> in Bouncer.h, but I might be wrong about making `VerifierParams` an empty subclass of `CommonParams`.